### PR TITLE
Connect-IC connect to Central function added

### DIFF
--- a/InContact/public/Connect-IC.ps1
+++ b/InContact/public/Connect-IC.ps1
@@ -1,72 +1,154 @@
 <#
 .SYNOPSIS
-Connects to an inContact Userhub instance.
+Fetches an access token for the inContact REST API
 
 .DESCRIPTION
-Call Connect-Ic to connect to an inContact Userhub instance (using its URL and credentials) before calling other inContact cmdlets. Identify your URI via https://developer.niceincontact.com/Documentation/UserHubGettingStarted
+Call Connect-Ic to connect to an inContact instance before calling other inContact cmdlets. 
+
+Stores key as script scoped var $Script:_IcToken
+
+-For UserHub-
+You will use an access token and use the appropriate URI for your geographic location
+Identify your URI and instruction on how to generate an access token: https://developer.niceincontact.com/Documentation/UserHubGettingStarted
+
+-For Central (Legacy Instance)-
+You will connect via OAUTH2. Use flag -Central parameter to connect
+Getting Started docs: https://developer.niceincontact.com/Documentation/GettingStarted
+
 
 .PARAMETER Uri
-The base URI of the inContact instance domain.
+The base URI of the inContact instance domain for Userhub instances
 
 .PARAMETER Credential
 Specifies a PSCredential object. For more information about the PSCredential object, type Get-Help Get-Credential.
 
 The PSCredential object provides the user ID and password for organizational ID credentials.
 
+For Userhub, this is your access key and access key secret pair.
+
+For Central, this is your central admin login.
+
+.PARAMETER Central
+Indicates you are connecting to a business unit that utilizes Central
+
+.PARAMETER Key
+BASE64 encoded string used for the OAUTH2 token retrevial in Central. 
+
+Specifically, base64 encoding of AppName@VendorName:BusinessUnitNumber
+API Application Generation Link: https://help.incontact.com/Content/ACD/APIApplications/APIApplications.htm
+
 .EXAMPLE
 
 Connect-Ic https://au1.nice-incontact.com -Credential (Get-Credential)
 
-Prompts for your username and password, then connects to the au1 inContact instance.
+Prompts for your username and password, then connects to the au1 inContact instance of Userhub
+
+.EXAMPLE
+
+Connect-Ic -Central -Credential (Get-Credential) -Key "QXBwTmFtZUBWZW5kb3JOYW1lOkJ1c2luZXNzVW5pdE51bWJlcg=="
+
 
 .NOTES
 See also: Disconnect-Ic.
 #>
 function Connect-IC {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='UserHub')]
     param (
         # The base URL of your Content Manager service API.
-        [Parameter(Mandatory,Position=0)]
+        [Parameter(Position=0,ParameterSetName='UserHub',Mandatory=$true)]
         [Alias('Url')]
         [uri]$Uri,
 
         # Secure login credentials for your Content Manager instance.
         [Parameter(Position=1)]
-        [PSCredential] $Credential
+        [PSCredential] $Credential,
+
+        [Parameter(ParameterSetName='Central',Position=2,Mandatory=$false)]
+        [switch] $Central,
+
+        [Parameter(ParameterSetName='Central',Mandatory=$true)]
+        [string] $Key
+
+
     )
 
+    #we use credential for both userhub and central
+    #for central, it's the Admin User's UN and PWD. Same login as logging in via login.incontact.com
+    #for userhub, it's the access key and access key pwd pairing as is generated on the end user.
     if ($null -eq $Credential) {
         $Credential = Get-Credential
     }
 
-    if ($Uri.OriginalString -notlike '*`/') {
-        $Uri = [uri]::new($Uri.OriginalString + '/')
-    }
-
-    $path = '/.well-known/cxone-configuration'
-
-    $endpoints  = Invoke-RestMethod -Uri ([uri]::new($Uri, $path))
-
-    $Script:_IcUri = [uri]::new($endpoints.api_endpoint)
-
-    $authUri = [uri]::new($endpoints.auth_endpoint)
 
     # Extract plain text password from credential
     $marshal = [Runtime.InteropServices.Marshal]
     $password = $marshal::PtrToStringAuto( $marshal::SecureStringToBSTR($Credential.Password) )
+    
 
-    $path = [uri]::new('/authentication/v1/token/access-key', [UriKind]::Relative)
-    $body = @{
-        accessKeyId = $Credential.UserName
-        accessKeySecret = $password
-    } | ConvertTo-Json
+    write-host $Credential.UserName
+
+
+
+    if($Central){ #CENTRAL AUTH
+        $Uri = "https://api.incontact.com/InContactAuthorizationServer/Token"
  
-    $result = Invoke-RestMethod -Method Post -Uri ([uri]::new($authUri, $path)) -Body $body -ContentType 'application/json'
-    if ($result.access_token) {
-        $Script:_IcToken = $result.access_token
-        Write-Verbose $Script:_IcUri
-        Write-Verbose $Script:_IcToken
-    } else {
-        throw "Could not connect to $Uri with the given credentials."
+    
+        $Body = @{'grant_type' = "password";} 
+        $Body += @{'username'   = $Credential.UserName;}
+        $Body += @{'password'   = "$Password";}
+        $Body += @{'scope'      = "$Scope"}
+    
+        $JsonBody = ConvertTo-Json $Body
+    
+        $Header = @{
+            'Authorization' = "basic $Key";
+            'Content-Type'  = 'application/json';
+        }
+    
+        $result = Invoke-RestMethod -Method POST -Uri $Uri -Body $JsonBody -Headers $Header
+    
+        if ($result.access_token) {
+            $Script:_IcToken = $result.access_token
+            $Script:_IcUri=[uri]::new($result.resource_server_base_uri)
+            Write-Verbose $Script:_IcUri
+            Write-Verbose $Script:_IcToken
+        } else {
+            throw "Could not fetch access token for Central with the given credentials."
+        } 
+
+    }
+    else{ #USERHUB AUTH
+
+       
+    
+        if ($Uri.OriginalString -notlike '*`/') {
+            $Uri = [uri]::new($Uri.OriginalString + '/')
+        }
+    
+        #userhub path
+        $path = '/.well-known/cxone-configuration'
+
+        $endpoints  = Invoke-RestMethod -Uri ([uri]::new($Uri, $path))
+
+        $Script:_IcUri = [uri]::new($endpoints.api_endpoint)
+
+        $authUri = [uri]::new($endpoints.auth_endpoint)
+
+
+
+        $path = [uri]::new('/authentication/v1/token/access-key', [UriKind]::Relative)
+        $body = @{
+            accessKeyId = $Credential.UserName
+            accessKeySecret = $password
+        } | ConvertTo-Json
+    
+        $result = Invoke-RestMethod -Method Post -Uri ([uri]::new($authUri, $path)) -Body $body -ContentType 'application/json'
+        if ($result.access_token) {
+            $Script:_IcToken = $result.access_token
+            Write-Verbose $Script:_IcUri
+            Write-Verbose $Script:_IcToken
+        } else {
+            throw "Could not connect to $Uri with the given credentials."
+        }   
     }    
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The module can be installed from the [PowerShell Gallery](https://www.powershell
 
     Install-Module inContact
 
-## Connect to an inContact Instance
+## Connect to an inContact Userhub Instance
 
 The first thing you'll need to do is connect to an inContact instance. We do this with Connect-IC, supplying a URL and credentials (your API Access Key and Access Secret).
 
@@ -18,6 +18,22 @@ The URL should be the root URL for your inContact domain. For example, to have P
     Connect-IC 'https://au1.nice-incontact.com' -Credential (Get-Credential)	
 
 Note that the token retrieved from Connect-IC expires in one hour, and we do not currently support refreshing the token automatically.
+
+
+## Connect to an inContact Central Instance
+
+Just like with a Userhub instance, the first thing you need to do is connect (fetch an access key). Central utilizes OAUTH2 instead of access key/secret pairs. 
+
+Things required for access:
+
+* Base64 Encoded Authorization Key (Steps 1 and 2 in https://developer.niceincontact.com/Documentation/GettingStarted) [-Key]
+* Admin login to Central [-Credential]
+
+
+   Connect-IC -Central -Credential (Get-Credential) -Key "Base64EncodedKey"
+   
+As with userhub, this token expires in one hour and is not automatically refreshed. 
+
 
 ## Disconnecting
 


### PR DESCRIPTION
Added Switch -Central (and corresponding -Key) to fetch auth key & api base URI for instances of inContact utilizing Central instead of userhub

Maintains existing functionality of first iteration of function unchanged _(though I wasn't able to test the actual connection to userhub as I don't have access to a userhub instance)_